### PR TITLE
Consolidate visual mode api

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ vim.g.maplocalleader = ','
 ## 🚀 Usage
 
 ### Opening and editing
-You can open a new *grug-far.nvim* vertical split buffer with the `:GrugFar` command. But possibly
-best to map a keybind to it for easy triggering.
+You can open a new *grug-far.nvim* vertical split buffer with the `:GrugFar` command.
+In visual mode, the command will pre-fill the search string with the current visual selection.
+Possibly best to map a keybind to it for easy triggering.
 Since it's *just a buffer*, you can edit in it as you see fit. The UI will try to guide
 you along and recover gracefully if you do things like `ggVGd` (delete all lines).
 Ultimately it leaves the power in your hands, and in any case recovery is just a few `u` taps away.
@@ -186,17 +187,19 @@ For more control, you can programmatically open a grug-far buffer like so:
 ```sh
 require('grug-far').grug_far(opts)
 ```
-or if you would like to pre-fill current visual selection as the search text:
+If the above is called while in visual mode, it will pre-fill current visual selection as search text.
 (note, this will also set `--fixed-strings` flag as selection can contain special characters)
+
+Note that if you want to pre-fill current visual selection from command mode, you would have to use: 
 ```
-require('grug-far').with_visual_selection(opts)
+:lua require('grug-far').with_visual_selection(opts)
 ```
 
 where `opts` will be merged with and override the global plugin options configured at setup time.
 
 See here for all the available [options][opts] 
 
-For more details on the API, see [docs][docs]
+For more API, see [docs][docs]
 
 ### 🥪 Cookbook
 

--- a/doc/grug-far.txt
+++ b/doc/grug-far.txt
@@ -28,7 +28,8 @@ your `init` file.
 
 Opens up a grug-far buffer in a vertical split. Multiple such buffers can
 be opened, each with their potentially different searches and they will
-show up in your buffers list.
+show up in your buffers list. In visual mode, it will pre-fill search
+with the current visual selection.
 
 ==============================================================================
 4. API                                                 *grug-far-api*
@@ -48,6 +49,8 @@ require('grug-far').grug_far({config})                *grug-far.grug_far()*
 	config that was passed to require('grug-far).setup(...). 
         Currently supported configuration options are the same as the global
 	plugin config options linked above.
+	If the function is called while in visual mode, it will pre-fill
+	search with the current visual selection.
 
         Parameters: ~
             {config}(optional, table) Table of values; keys as described

--- a/lua/grug-far.lua
+++ b/lua/grug-far.lua
@@ -294,7 +294,6 @@ function M.toggle_instance(options)
   end
 
   if not namedInstances[options.instanceName] then
-    -- TODO (sbadragan): call internal?
     M.grug_far(options)
     return
   end

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -50,6 +50,10 @@ M.defaultOptions = {
   -- row in the window to position the cursor at at start
   startCursorRow = 3,
 
+  -- by default, in visual mode, the visual selection is used to prefill the search
+  -- setting this option to true disables that behaviour
+  ignoreVisualSelection = false,
+
   -- shortcuts for the actions you see at the top of the buffer
   -- set to '' or false to unset. Mappings with no normal mode value will be removed from the help header
   -- you can specify either a string which is then used as the mapping for both normmal and insert mode
@@ -306,6 +310,7 @@ M.defaultOptions = {
 ---@field staticTitle? string
 ---@field startInInsertMode boolean
 ---@field startCursorRow integer
+---@field ignoreVisualSelection boolean
 ---@field keymaps Keymaps
 ---@field resultsSeparatorLineChar string
 ---@field resultsHighlight boolean
@@ -330,6 +335,7 @@ M.defaultOptions = {
 ---@field staticTitle? string
 ---@field startInInsertMode? boolean
 ---@field startCursorRow? integer
+---@field ignoreVisualSelection? boolean
 ---@field keymaps? KeymapsOverride
 ---@field resultsSeparatorLineChar? string
 ---@field spinnerStates? string[] | false
@@ -345,20 +351,7 @@ M.defaultOptions = {
 ---@param defaults GrugFarOptions
 ---@return GrugFarOptions
 function M.with_defaults(options, defaults)
-  local newOptions = vim.tbl_deep_extend('force', defaults, options)
-
-  -- deprecated prop names
-  newOptions.placeholders.filesFilter = (
-    options.placeholders
-    and (options.placeholders.filesFilter or options.placeholders.filesGlob)
-  ) or defaults.placeholders.filesFilter
-
-  if options.placeholders and options.placeholders.filesGlob then
-    vim.notify(
-      'grug-far: options.placeholders.filesGlob deprecated. Please use options.placeholders.filesFilter instead!',
-      vim.log.levels.WARN
-    )
-  end
+  local newOptions = vim.tbl_deep_extend('force', vim.deepcopy(defaults), options)
 
   -- normalize keymaps opts
   for key, value in pairs(newOptions.keymaps) do


### PR DESCRIPTION
`GrugFar` command and `require('grug-far').grug_far(opts)` will now pre-fill search with visual selection in visual mode.

`with_visual_selection(opts)` is only necessary if you want to use the visual selection from lua command mode. ex:
```
:lua require('grug-far').with_visual_selection(opts)
```

fixes https://github.com/MagicDuck/grug-far.nvim/issues/119