### PR TITLE
Update README requirements to Include ripgrep Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Grug find! Grug replace! Grug happy!
 ## ⚡️ Requirements
 
 - Neovim >= **0.9.5** (might work with lower versions)
-- [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep)
+- [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep) >= 14 recommended
 - a [Nerd Font](https://www.nerdfonts.com/) **_(optional)_**
 
 Run `:checkhealth grug-far` if you see unexpected issues.


### PR DESCRIPTION
Grug requires the use of the recently added `--hyperlink-format` flag (introduced in `rg` release [14.0](https://github.com/BurntSushi/ripgrep/releases/tag/14.0.0)).

Many Debian instances (e.g., WSL running Ubuntu-22.04) have a stable packaged ripgrep instance of version 13.0.0.

To clarify dependencies to users I suggest we add the `rg` dependency requirement to the readme. This way we avoid breaking any builds, but still inform users about constraints.