### PR TITLE
feat: add the ability to create transient search buffers

### DIFF
--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -168,7 +168,7 @@ local function updateBufName(buf, context)
       )
   end
 
-  vim.api.nvim_buf_set_name(buf, title)
+  utils.buf_set_name(buf, title)
 end
 
 ---@param buf integer

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -203,7 +203,7 @@ end
 ---@param context GrugFarContext
 ---@return integer bufId
 function M.createBuffer(win, context)
-  local buf = vim.api.nvim_create_buf(true, true)
+  local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_set_option_value('filetype', 'grug-far', { buf = buf })
   vim.api.nvim_set_option_value('swapfile', false, { buf = buf })
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = buf })

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -207,6 +207,10 @@ function M.createBuffer(win, context)
   vim.api.nvim_set_option_value('filetype', 'grug-far', { buf = buf })
   vim.api.nvim_set_option_value('swapfile', false, { buf = buf })
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = buf })
+  -- automatically wipe hidden non-named instance sessions
+  if not context.options.instanceName then
+    vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = buf })
+  end
   vim.api.nvim_win_set_buf(win, buf)
 
   setupGlobalOptOverrides(buf, context)

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -203,12 +203,12 @@ end
 ---@param context GrugFarContext
 ---@return integer bufId
 function M.createBuffer(win, context)
-  local buf = vim.api.nvim_create_buf(false, true)
+  local buf = vim.api.nvim_create_buf(context.options.transient, true)
   vim.api.nvim_set_option_value('filetype', 'grug-far', { buf = buf })
   vim.api.nvim_set_option_value('swapfile', false, { buf = buf })
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = buf })
-  -- automatically wipe hidden non-named instance sessions
-  if not context.options.instanceName then
+  -- settings for transient buffers
+  if context.options.transient then
     vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = buf })
   end
   vim.api.nvim_win_set_buf(win, buf)

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -53,6 +53,9 @@ M.defaultOptions = {
   -- whether to wrap text in the grug-far buffer
   wrap = true,
 
+  -- whether or not to make a transient buffer which is both unlisted and fully deletes itself when not in use
+  transient = false,
+
   -- by default, in visual mode, the visual selection is used to prefill the search
   -- setting this option to true disables that behaviour
   ignoreVisualSelection = false,
@@ -314,6 +317,7 @@ M.defaultOptions = {
 ---@field startInInsertMode boolean
 ---@field startCursorRow integer
 ---@field wrap boolean
+---@field transient boolean
 ---@field ignoreVisualSelection boolean
 ---@field keymaps Keymaps
 ---@field resultsSeparatorLineChar string
@@ -340,6 +344,7 @@ M.defaultOptions = {
 ---@field startInInsertMode? boolean
 ---@field startCursorRow? integer
 ---@field wrap? integer
+---@field transient? boolean
 ---@field ignoreVisualSelection? boolean
 ---@field keymaps? KeymapsOverride
 ---@field resultsSeparatorLineChar? string

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -343,7 +343,7 @@ M.defaultOptions = {
 ---@field staticTitle? string
 ---@field startInInsertMode? boolean
 ---@field startCursorRow? integer
----@field wrap? integer
+---@field wrap? boolean
 ---@field transient? boolean
 ---@field ignoreVisualSelection? boolean
 ---@field keymaps? KeymapsOverride


### PR DESCRIPTION
When opening grug, it essentially creates a "temporary window" which I don't want to show up in my tabline/bufferline plugins. This makes it so that the buffer is unlisted similar to other similar plugins such as `nvim-spectre`.


Thanks so much for an awesome plugin!