### PR TITLE
fix: use `IncSearch` for default results matching highlight

### DIFF
--- a/lua/grug-far/highlights.lua
+++ b/lua/grug-far/highlights.lua
@@ -18,7 +18,7 @@ local highlights = {
   GrugFarResultsStats = { default = true, link = 'Comment' },
   GrugFarResultsActionMessage = { default = true, link = 'ModeMsg' },
 
-  GrugFarResultsMatch = { default = true, link = '@diff.delta' },
+  GrugFarResultsMatch = { default = true, link = 'IncSearch' },
   GrugFarResultsPath = { default = true, link = '@string.special.path' },
   GrugFarResultsLineNo = { default = true, link = 'Number' },
   GrugFarResultsLineColumn = { default = true, link = 'Number' },


### PR DESCRIPTION
This is a small recommendation for the default highlight group for the `GrugFarResultsMatch` group. Currently it's set to `@diff.delta`, but `IncSearch` seems like a more semantically relevant highlight group.

Here is from `:h IncSearch`:

> 'incsearch' highlighting; also used for the text replaced with ":s///c".

Let me know what you think. I'm also okay if you disagree with this change and say it's up to colorschemes to make it look how they want. 