### PR TITLE
fixing crash in nighly due to extmarks being cleared after buffer lines are removed

### DIFF
--- a/lua/grug-far/render/resultsList.lua
+++ b/lua/grug-far/render/resultsList.lua
@@ -334,8 +334,8 @@ end
 function M.clear(buf, context)
   -- remove all lines after heading and add one blank line
   local headerRow = context.state.headerRow
-  setBufLines(buf, headerRow, -1, false, { '' })
   vim.api.nvim_buf_clear_namespace(buf, context.locationsNamespace, 0, -1)
+  setBufLines(buf, headerRow, -1, false, { '' })
   context.state.resultLocationByExtmarkId = {}
   context.state.resultsLastFilename = nil
   context.state.resultMatchLineCount = 0


### PR DESCRIPTION
fixes https://github.com/MagicDuck/grug-far.nvim/issues/234