### PR TITLE
File explorer recipe improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,73 +304,51 @@ Create nvim-tree hotkey `z` that will create/open named instance `tree` of grug-
 <details>
 <summary>Nvim tree lazy plugin setup</summary>
 
+Small video of it in action: https://github.com/MagicDuck/grug-far.nvim/issues/165#issuecomment-2257439367
+
 ```lua
 return {
   "nvim-tree/nvim-tree.lua",
   dependencies = "nvim-tree/nvim-web-devicons",
   config = function()
-    local nvimtree = require("nvim-tree")
-
-    -- custom on attach function to remove some default mappings and add custom ones
-    local function my_on_attach(bufnr)
-      local api = require("nvim-tree.api")
-      local lib = require("nvim-tree.lib")
-
-      local function opts(desc)
-        return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
-      end
-
-      -- defaults
-      api.config.mappings.default_on_attach(bufnr)
-
-      -- add custom key mapping to search in directory with grug-far
-      vim.keymap.set("n", "z", function()
-        local node = lib.get_node_at_cursor()
-        local grugFar = require("grug-far")
-        if node then
-          -- get directory of current file if it's a file
-          local path
-          if node.type == "directory" then
-            -- Keep the full path for directories
-            path = node.absolute_path
-          else
-            -- Get the directory of the file
-            path = vim.fn.fnamemodify(node.absolute_path, ":h")
-          end
-
-          -- escape all spaces in the path with "\ "
-          path = path:gsub(" ", "\\ ")
-
+    -- https://github.com/nvim-tree/nvim-tree.lua/blob/master/lua/nvim-tree.lua#L342
+    require("nvim-tree").setup {
+      commands = {
+        -- create a new neo-tree command
+        grug_far_replace = function(state)
+          local node = state.tree:get_node()
           local prefills = {
-            paths = path,
+            -- get the current path and get the parent directory if a file is selected
+            paths = node.type == "directory" and node:get_id() or vim.fn.fnamemodify(node:get_id(), ":h"),
           }
 
+          local grug_far = require "grug-far"
           -- instance check
-          if not grugFar.has_instance("tree") then
-            grugFar.open({
-              instanceName = "tree",
+          if not grug_far.has_instance "explorer" then
+            grug_far.open {
+              instanceName = "explorer",
               prefills = prefills,
-              staticTitle = "Find and Replace from Tree",
-            })
+              staticTitle = "Find and Replace from Explorer",
+            }
           else
-            grugFar.open_instance("tree")
+            grug_far.open_instance "explorer"
             -- updating the prefills without clearing the search and other fields
-            grugFar.update_instance_prefills("tree", prefills, false)
+            grug_far.update_instance_prefills("explorer", prefills, false)
           end
-        end
-      end, opts("Search in directory"))
-    end
-
-    -- https://github.com/nvim-tree/nvim-tree.lua/blob/master/lua/nvim-tree.lua#L342
-    nvimtree.setup({
-      on_attach = my_on_attach,
+        end,
+      },
+      window = {
+        mappings = {
+          -- map our new command to z
+          z = "grug_far_replace",
+        },
+      },
       -- rest of your config
-    })
+    }
   end,
 }
 ```
 </details>
-Small video of it in action: https://github.com/MagicDuck/grug-far.nvim/issues/165#issuecomment-2257439367
 
 ## ❓ Q&A
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,46 @@ return {
 ```
 </details>
 
+<details>
+<summary>Oil explorer lazy plugin setup</summary>
+
+```lua
+return {
+  "stevearc/oil.nvim",
+  config = function()
+    local oil = require "oil"
+    oil.setup {
+      keymaps = {
+        -- create a new mapping, gs, to search and replace in the current directory
+        gs = {
+          callback = function()
+            -- get the current directory
+            local prefills = { paths = oil.get_current_dir() }
+
+            local grug_far = require "grug-far"
+            -- instance check
+            if not grug_far.has_instance "explorer" then
+              grug_far.open {
+                instanceName = "explorer",
+                prefills = prefills,
+                staticTitle = "Find and Replace from Explorer",
+              }
+            else
+              grug_far.open_instance "explorer"
+              -- updating the prefills without clearing the search and other fields
+              grug_far.update_instance_prefills("explorer", prefills, false)
+            end
+          end,
+          desc = "oil: Search in directory",
+        },
+      },
+      -- rest of your config
+    }
+  end,
+}
+```
+</details>
+
 ## ❓ Q&A
 
 #### 1. Getting RPC[Error] ... Document for URI could not be found: file:///.../Grug%20FAR%20-%20...


### PR DESCRIPTION
I noticed there is a really cool new recipe for neo-tree integration with grug-far! This is super awesome, so I wanted to recommend an improvement that utilizes the built in command/mapping features in Neo-tree. This also means that the new binding shows up in the neo-tree help when you press `?`.

I also added a similar recipe for adding the same type of command in oil.nvim.

Let me know what you think!