### PR TITLE
Visual selection utility fixes

### DIFF
--- a/doc/grug-far.txt
+++ b/doc/grug-far.txt
@@ -143,19 +143,29 @@ require('grug-far').update_instance_prefills({instanceName}, {prefills}, {clearO
 	       {search=, replacement=, filesFilter=, flags=, paths=}
             {clearOld}(boolean) if given, old input values are ignored
 
-require('grug-far').get_current_visual_selection()  *grug-far.get_current_visual_selection()*
+require('grug-far').get_current_visual_selection({strict})
+                                              *grug-far.get_current_visual_selection()*
 	Gets the current visual selection as a string.
 	This is provided as a utility for users so they don't have to rewrite.
-	
-	Return: ~
-	    {visual_selection}(string) 
 
-require('grug-far').get_current_visual_selection_lines()  *grug-far.get_current_visual_selection_lines()*
+        Parameters: ~
+            {strict}(boolean) If true, only return selection if currently in
+	      visual mode
+
+	Return: ~
+	    {visual_selection}(string)
+
+require('grug-far').get_current_visual_selection_lines({strict})
+                                        *grug-far.get_current_visual_selection_lines()*
 	Gets the current visual selection as a string array for each line.
 	This is provided as a utility for users so they don't have to rewrite.
-	
+
+        Parameters: ~
+            {strict}(boolean) If true, only return selection if currently in
+	      visual mode
+
 	Return: ~
-	    {visual_selection}(string[]) 
+	    {visual_selection}(string[])
 
 ==============================================================================
 4. Highlights                                          *grug-far-highlights*

--- a/doc/grug-far.txt
+++ b/doc/grug-far.txt
@@ -150,6 +150,13 @@ require('grug-far').get_current_visual_selection()  *grug-far.get_current_visual
 	Return: ~
 	    {visual_selection}(string) 
 
+require('grug-far').get_current_visual_selection_split()  *grug-far.get_current_visual_selection_split()*
+	Gets the current visual selection as a string array for each line.
+	This is provided as a utility for users so they don't have to rewrite.
+	
+	Return: ~
+	    {visual_selection}(string[]) 
+
 ==============================================================================
 4. Highlights                                          *grug-far-highlights*
 

--- a/doc/grug-far.txt
+++ b/doc/grug-far.txt
@@ -150,7 +150,7 @@ require('grug-far').get_current_visual_selection()  *grug-far.get_current_visual
 	Return: ~
 	    {visual_selection}(string) 
 
-require('grug-far').get_current_visual_selection_split()  *grug-far.get_current_visual_selection_split()*
+require('grug-far').get_current_visual_selection_lines()  *grug-far.get_current_visual_selection_lines()*
 	Gets the current visual selection as a string array for each line.
 	This is provided as a utility for users so they don't have to rewrite.
 	

--- a/lua/grug-far.lua
+++ b/lua/grug-far.lua
@@ -252,12 +252,8 @@ function M.open(options)
   ensure_configured()
   local resolvedOpts = opts.with_defaults(options or {}, globalOptions)
   local is_visual = false
-  if not resolvedOpts.ignoreVisualSelection and vim.fn.mode():lower():find('v') ~= nil then
-    is_visual = true
-  end
-  if is_visual then
-    -- needed to make visual selection work
-    vim.cmd([[normal! vv]])
+  if not resolvedOpts.ignoreVisualSelection then
+    is_visual = utils.leaveVisualMode()
   end
 
   return M._open_internal(resolvedOpts, { is_visual = is_visual })
@@ -422,11 +418,7 @@ end
 function M.with_visual_selection(options)
   ensure_configured()
 
-  local isVisualMode = vim.fn.mode():lower():find('v') ~= nil
-  if isVisualMode then
-    -- needed to make visual selection work
-    vim.cmd([[normal! vv]])
-  end
+  utils.leaveVisualMode()
 
   local resolvedOpts = opts.with_defaults(options or {}, globalOptions)
   return M._open_internal(resolvedOpts, { is_visual = true })
@@ -436,12 +428,7 @@ end
 --- This is provided as a utility for users so they don't have to rewrite
 ---@return string
 function M.get_current_visual_selection()
-  local isVisualMode = vim.fn.mode():lower():find('v') ~= nil
-  if isVisualMode then
-    -- needed to make visual selection work
-    vim.cmd([[normal! vv]])
-  end
-
+  utils.leaveVisualMode()
   local selection_lines = utils.getVisualSelectionLines()
   return vim.fn.join(selection_lines, '\n')
 end

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -73,7 +73,7 @@ M.DiffSeparatorChars = ' '
 ---@field replace fun(params: EngineReplaceParams): (abort: fun()?) performs replace
 ---@field isSyncSupported fun(): boolean whether sync operation is supported
 ---@field sync fun(params: EngineSyncParams): (abort: fun()?) syncs given changes to their originating files
----@field getInputPrefillsForVisualSelection fun(initialPrefills: GrugFarPrefills): GrugFarPrefills gets prefills updated with visual selection searchand any additional flags that are necessary (for example --fixed-strings for rg)
+---@field getInputPrefillsForVisualSelection fun(visual_selection: string[], initialPrefills: GrugFarPrefills): GrugFarPrefills gets prefills updated with visual selection searchand any additional flags that are necessary (for example --fixed-strings for rg)
 
 --- returns engine given type
 ---@param type GrugFarEngineType

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -27,10 +27,9 @@ local AstgrepEngine = {
     -- not supported
   end,
 
-  getInputPrefillsForVisualSelection = function(initialPrefills)
+  getInputPrefillsForVisualSelection = function(visual_selection, initialPrefills)
     local prefills = vim.deepcopy(initialPrefills)
-    local selection_lines = utils.getVisualSelectionLines()
-    prefills.search = vim.fn.join(selection_lines, '\n')
+    prefills.search = vim.fn.join(visual_selection, '\n')
     return prefills
   end,
 }

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -1,4 +1,3 @@
-local utils = require('grug-far/utils')
 local search = require('grug-far/engine/astgrep/search')
 local replace = require('grug-far/engine/astgrep/replace')
 

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -1,7 +1,6 @@
 local search = require('grug-far/engine/ripgrep/search')
 local replace = require('grug-far/engine/ripgrep/replace')
 local sync = require('grug-far/engine/ripgrep/sync')
-local utils = require('grug-far/utils')
 
 ---@type GrugFarEngine
 local RipgrepEngine = {

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -26,16 +26,15 @@ local RipgrepEngine = {
 
   sync = sync.sync,
 
-  getInputPrefillsForVisualSelection = function(initialPrefills)
+  getInputPrefillsForVisualSelection = function(visual_selection, initialPrefills)
     local prefills = vim.deepcopy(initialPrefills)
 
-    local selection_lines = utils.getVisualSelectionLines()
-    prefills.search = vim.fn.join(selection_lines, '\n')
+    prefills.search = vim.fn.join(visual_selection, '\n')
     local flags = prefills.flags or ''
     if not flags:find('%-%-fixed%-strings') then
       flags = (#flags > 0 and flags .. ' ' or flags) .. '--fixed-strings'
     end
-    if #selection_lines > 1 and not flags:find('%-%-multiline') then
+    if #visual_selection > 1 and not flags:find('%-%-multiline') then
       flags = (#flags > 0 and flags .. ' ' or flags) .. '--multiline'
     end
     prefills.flags = flags

--- a/lua/grug-far/utils.lua
+++ b/lua/grug-far/utils.lua
@@ -268,6 +268,17 @@ function M.ensureBufTopEmptyLines(buf, count)
   end
 end
 
+--- leave visual mode if in visual mode
+---@return boolean if left visual mode
+function M.leaveVisualMode()
+  local isVisualMode = vim.fn.mode():lower():find('v') ~= nil
+  if isVisualMode then
+    -- needed to make visual selection work
+    vim.fn.feedkeys(':', 'nx')
+  end
+  return isVisualMode
+end
+
 --- get text lines in visual selection
 ---@return string[]
 function M.getVisualSelectionLines()

--- a/lua/grug-far/utils.lua
+++ b/lua/grug-far/utils.lua
@@ -274,7 +274,7 @@ function M.getVisualSelectionLines()
   local start_row, start_col = unpack(vim.api.nvim_buf_get_mark(0, '<'))
   local end_row, end_col = unpack(vim.api.nvim_buf_get_mark(0, '>'))
   local lines = vim.fn.getline(start_row, end_row) --[[ @as string[] ]]
-  if #lines > 0 and start_col and end_col then
+  if #lines > 0 and start_col and end_col and end_col < string.len(lines[#lines]) then
     if start_row == end_row then
       lines[1] = lines[1]:sub(start_col + 1, end_col + 1)
     else


### PR DESCRIPTION
While playing around with the visual selection functionality I found a couple bugs.

1. When using visual line mode the functionality was just broken. Mainly because when visual line mode is used, the end_col and start_col will be out of bounds of the line. This makes sure to only trim the lines if the start_col and end_col are in the bounds of the lines
2. With the new ability to get the visual mode to pass into `update_prefills` I noticed that the current method for "leave visual mode" actually puts you into selection mode in the already open instance of grug-far which is very disorienting. This changes the method of leaving visual mode before getting the selection so that when updating the prefills you end up in the mode you expect in the grug-far window. While fixing this, I also normalized the use of this functionality to a utility function so there is a single place to change how to "leave visual mode"
3. Adds a second function `get_current_visual_selection_split`. This is useful internally and could be useful for the end user.
4. Refactors the code so that all locations where the visual selection is retrieved it is gotten through `get_current_visual_selection_split` so the logic is centralized and easier to maintain in the future and to populate bug fixes across all locations in the code.

Let me know what you think!