### PR TITLE
docs: add recipe for searching and replacing in mini.files

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ return {
     })
 
     
-    local files_grug_far_cwd = function(path)
+    local files_grug_far_replace = function(path)
       -- works only if cursor is on the valid file system entry
       local cur_entry_path = MiniFiles.get_fs_entry().path
       local prefills = { paths = vim.fs.dirname(cur_entry_path) }
@@ -450,7 +450,7 @@ return {
     vim.api.nvim_create_autocmd("User", {
       pattern = "MiniFilesBufferCreate",
       callback = function(args)
-        vim.keymap.set("n", "gs", files_grug_far_cwd, { buffer = args.data.buf_id, desc = "Search in directory" })
+        vim.keymap.set("n", "gs", files_grug_far_replace, { buffer = args.data.buf_id, desc = "Search in directory" })
       end,
     })
   end,

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ vim.api.nvim_create_autocmd('FileType', {
 
 #### Add nvim-tree integration to open search limited to focused directory or file
 
-Create nvim-tree hotkey `z` that will create/open named instance `tree` of grug-far with the current directory of the file or directory in focus. On the second trigger, path of the `tree` grug-far instance will be updates, leaving other fields intact
+Create a hotkey `z` in `nvim-tree` that will create/open a named instance of grug-far with the current directory of the file or directory in focus. On the second trigger, path of the grug-far instance will be updated, leaving other fields intact.
 
 <details>
 <summary>Nvim tree lazy plugin setup</summary>
@@ -372,6 +372,10 @@ return {
 ```
 </details>
 
+#### Add oil.nvim integration to open search limited to focused directory
+
+Create a hotkey `gs` in `oil.nvim` that will create/open a named instance of grug-far with the current directory in focus. On the second trigger, path of the grug-far instance will be updated, leaving other fields intact.
+
 <details>
 <summary>Oil explorer lazy plugin setup</summary>
 
@@ -411,6 +415,10 @@ return {
 }
 ```
 </details>
+
+#### Add mini.files integration to open search limited to focused directory
+
+Create a hotkey `gs` in `mini.files` that will create/open a named instance of grug-far with the current directory in focus. On the second trigger, the path of the grug-far instance will be updated, leaving other fields intact.
 
 <details>
 <summary>MiniFiles explorer lazy plugin setup</summary>

--- a/README.md
+++ b/README.md
@@ -412,6 +412,52 @@ return {
 ```
 </details>
 
+<details>
+<summary>MiniFiles explorer lazy plugin setup</summary>
+
+```lua
+return {
+  "echasnovski/mini.files",
+  config = function()
+    local MiniFiles = require "mini.files"
+
+    MiniFiles.setup({
+      -- your config
+    })
+
+    
+    local files_grug_far_cwd = function(path)
+      -- works only if cursor is on the valid file system entry
+      local cur_entry_path = MiniFiles.get_fs_entry().path
+      local prefills = { paths = vim.fs.dirname(cur_entry_path) }
+
+      local grug_far = require "grug-far"
+
+      -- instance check
+      if not grug_far.has_instance "explorer" then
+        grug_far.open {
+          instanceName = "explorer",
+          prefills = prefills,
+          staticTitle = "Find and Replace from Explorer",
+        }
+      else
+        grug_far.open_instance "explorer"
+        -- updating the prefills without crealing the search and other fields
+        grug_far.update_instance_prefills("explorer", prefills, false)
+      end
+    end
+
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "MiniFilesBufferCreate",
+      callback = function(args)
+        vim.keymap.set("n", "gs", files_grug_far_cwd, { buffer = args.data.buf_id, desc = "Search in directory" })
+      end,
+    })
+  end,
+}
+```
+</details>
+
 ## ❓ Q&A
 
 #### 1. Getting RPC[Error] ... Document for URI could not be found: file:///.../Grug%20FAR%20-%20...


### PR DESCRIPTION
This PR addresses issue [#257](https://github.com/MagicDuck/grug-far.nvim/issues/257) by adding an integration recipe for using `grug-far.nvim` with `mini.files`.

Implemented a recipe that allows users to easily search within the current directory using grug-far while navigating files with mini.files. Fixed a couple of minor issues in the original recipe provided in the issue.