### PR TITLE
perf(treesitter): lazily get parser and set regions early

### DIFF
--- a/lua/grug-far/render/treesitter.lua
+++ b/lua/grug-far/render/treesitter.lua
@@ -101,10 +101,11 @@ function M._attach_lang(buf, lang, regions, regionsId)
   end
 
   if not entry then
-    local ok, parser = pcall(vim.treesitter.get_parser, buf, lang)
+    local ok, parser = pcall(vim.treesitter.languagetree.new, buf, lang)
     if not ok then
       return
     end
+    parser:set_included_regions(regions)
     M.cache[buf][cacheKey] = {
       parser = parser,
       highlighter = TSHighlighter.new(parser),


### PR DESCRIPTION
The get_parser and TSHighlight:new both parse the buffer which takes a lot of time since there are many error nodes, so set regions early to prevent this.
Fixes #286 