### PR TITLE
make keymaps' description shorter

### DIFF
--- a/lua/grug-far/actions/historyOpen.lua
+++ b/lua/grug-far/actions/historyOpen.lua
@@ -82,7 +82,7 @@ local function setupKeymap(historyWin, historyBuf, buf, context)
   local keymaps = context.options.keymaps
   utils.setBufKeymap(
     historyBuf,
-    'Grug Far: pick history entry',
+    'Pick history entry',
     keymaps.pickHistoryEntry,
     function()
       pickHistoryEntry(historyWin, historyBuf, buf, context)

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -276,7 +276,7 @@ function M.createBuffer(win, context)
   setupGlobalOptOverrides(buf, context)
   context.actions = getActions(buf, context)
   for _, action in ipairs(context.actions) do
-    utils.setBufKeymap(buf, 'Grug Far: ' .. action.text, action.keymap, action.action)
+    utils.setBufKeymap(buf, action.text, action.keymap, action.action)
   end
   inputs.bindInputSaavyKeys(context, buf)
 


### PR DESCRIPTION
Since the mappings created by the plugin are local to the grug buffers, it shouldn't be necessary to put 'Grug Far: ' as a prefix.