### PR TITLE
fix(quickfix list): avoid clobbering existing lists

### DIFF
--- a/lua/grug-far/actions/qflist.lua
+++ b/lua/grug-far/actions/qflist.lua
@@ -5,7 +5,7 @@ local utils = require('grug-far.utils')
 ---@param resultsLocations ResultLocation[]
 local function openQuickfixList(context, resultsLocations)
   local search = context.state.inputs.search
-  vim.fn.setqflist(resultsLocations, 'r')
+  vim.fn.setqflist(resultsLocations, ' ')
   vim.fn.setqflist({}, 'a', {
     title = 'Grug FAR results'
       .. utils.strEllideAfter(search, context.options.maxSearchCharsInTitles, ' for: '),


### PR DESCRIPTION
I've found a small issue with the quickfix list integration.

Setting the replace flag when sending grug-far results into the quickfix list truncates existing results. That's a problem because the quickfix list keeps a history of all the lists generated during the session, and you can navigate the history with `:cprev` and `:cnext`. Which means that populating the list from grug overtakes whatever list is currently displaying.

For example, imagine you have the lists in `:chistory`

| | order | title |
|--------|--------|--------|
| | 1 | LSP references |
| | 2 | Some other plugin list |
| * | 3 | LSP references |

Then you navigate back to see the second list with `:cprev`.

| | order | title |
|--------|--------|--------|
| | 1 | LSP references |
| * | 2 | Some other plugin list |
| | 3 | LSP references |

Then you use grug-far and send the results to the list:

| | order | title |
|--------|--------|--------|
| | 1 | LSP references |
| * | 2 | Grug FAR results for: someString |
| | 3 | LSP references |

Now I've lost `Some other plugin list`.

Inserting a brand new entry seems like the desired behavior, not only prevents clobbering existing lists, but also helps you navigate previous grug-far results without opening the grug-far ui first.