### PR TITLE
Refactoring so that inputs are specified per-engine

### DIFF
--- a/lua/grug-far.lua
+++ b/lua/grug-far.lua
@@ -126,6 +126,7 @@ local contextCount = 0
 ---@field highlightRegions LangRegions
 ---@field normalModeSearch boolean
 ---@field searchDisabled boolean
+---@field previousInputValues { [string]: string }
 
 ---@class GrugFarAction
 ---@field text string
@@ -184,6 +185,7 @@ local function createContext(options)
       highlightResults = {},
       normalModeSearch = options.normalModeSearch,
       searchDisabled = false,
+      previousInputValues = {},
     },
     winDefaultOpts = {},
   }

--- a/lua/grug-far.lua
+++ b/lua/grug-far.lua
@@ -439,7 +439,7 @@ end
 --- updates grug-far instance with given input prefills
 --- if clearOld=true is given, the old input values are ignored
 ---@param instanceName string
----@param prefills GrugFarPrefillsOverride
+---@param prefills GrugFarPrefills
 ---@param clearOld boolean
 function M.update_instance_prefills(instanceName, prefills, clearOld)
   ensure_configured()

--- a/lua/grug-far/actions/historyOpen.lua
+++ b/lua/grug-far/actions/historyOpen.lua
@@ -8,10 +8,11 @@ local replacementInterpreter = require('grug-far.replacementInterpreter')
 local inputs = require('grug-far.inputs')
 
 --- gets history entry at given 0-based buffer row
+---@param context GrugFarContext
 ---@param historyBuf integer
 ---@param row integer
 ---@return HistoryEntry | nil
-local function getHistoryEntryAtRow(historyBuf, row)
+local function getHistoryEntryAtRow(context, historyBuf, row)
   local firstEntryRow = nil
   for i = row, 0, -1 do
     local bufline = unpack(vim.api.nvim_buf_get_lines(historyBuf, i, i + 1, false))
@@ -36,7 +37,7 @@ local function getHistoryEntryAtRow(historyBuf, row)
   end
 
   local entryLines = vim.api.nvim_buf_get_lines(historyBuf, firstEntryRow, lastEntryRow + 1, false)
-  local entry = history.getHistoryEntryFromLines(entryLines)
+  local entry = history.getHistoryEntryFromLines(context, entryLines)
   return entry
 end
 
@@ -54,7 +55,7 @@ end
 ---@param context GrugFarContext
 local function pickHistoryEntry(historyWin, historyBuf, buf, context)
   local cursor_row = unpack(vim.api.nvim_win_get_cursor(0)) - 1
-  local entry = getHistoryEntryAtRow(historyBuf, cursor_row)
+  local entry = getHistoryEntryAtRow(context, historyBuf, cursor_row)
   if not entry then
     return
   end

--- a/lua/grug-far/actions/qflist.lua
+++ b/lua/grug-far/actions/qflist.lua
@@ -5,11 +5,13 @@ local utils = require('grug-far.utils')
 ---@param context GrugFarContext
 ---@param resultsLocations ResultLocation[]
 local function openQuickfixList(buf, context, resultsLocations)
-  local search = context.state.inputs.search
   vim.fn.setqflist(resultsLocations, ' ')
   vim.fn.setqflist({}, 'a', {
-    title = 'Grug FAR results'
-      .. utils.strEllideAfter(search, context.options.maxSearchCharsInTitles, ' for: '),
+    title = 'Grug FAR results' .. utils.strEllideAfter(
+      context.engine.getSearchDescription(context.state.inputs),
+      context.options.maxSearchCharsInTitles,
+      ' for: '
+    ),
   })
 
   -- open/goto target win so that quickfix list will open items into the terget win

--- a/lua/grug-far/actions/search.lua
+++ b/lua/grug-far/actions/search.lua
@@ -146,22 +146,6 @@ local function search(params)
     end)
   )
 
-  local numSearchChars = #state.inputs.search
-  if numSearchChars > 0 and numSearchChars < (context.options.minSearchChars or 1) then
-    table.insert(update_queue, {
-      params = {
-        'success',
-        nil,
-        'Please enter at least '
-          .. context.options.minSearchChars
-          .. ' search chars to trigger search!',
-      },
-      type = SearchUpdateType.Finish,
-    })
-
-    return
-  end
-
   local fetched_matches = 0
   abort, effectiveArgs = context.engine.search({
     inputs = state.inputs,

--- a/lua/grug-far/actions/swapEngine.lua
+++ b/lua/grug-far/actions/swapEngine.lua
@@ -1,5 +1,6 @@
 local search = require('grug-far.actions.search')
 local engine = require('grug-far.engine')
+local inputs = require('grug-far.inputs')
 
 --- swaps engine with the next one
 ---@param params { buf: integer, context: GrugFarContext }
@@ -12,12 +13,38 @@ local function swapEngine(params)
   local nextIndex = (currentIndex + 1) % #engineTypes
   local nextEngineType = engineTypes[nextIndex + 1]
   context.engine = engine.getEngine(nextEngineType)
-  vim.notify('grug-far: swapped to engine: ' .. context.engine.type .. '!', vim.log.levels.INFO)
-  search({ buf = buf, context = context })
 
-  -- TODO (sbadragan): need to somehow clear the extmark that was rendered for Search: input...
-  -- and the associated value
-  -- then fillInput with default for the ones that have a default.
+  -- get the values and stuff them into savedValues
+  for name, value in pairs(context.state.inputs) do
+    context.state.previousInputValues[name] = value
+  end
+  -- clear the values and input label extmarks from the buffer
+  local emptyValues = {}
+  for _, input in ipairs(context.engine.inputs) do
+    emptyValues[input.name] = ''
+  end
+  inputs.fill(context, buf, emptyValues, true)
+  vim.api.nvim_buf_clear_namespace(buf, context.namespace, 0, -1)
+
+  -- fill in inputs
+  local values = {}
+  for _, input in ipairs(context.engine.inputs) do
+    local value = context.state.previousInputValues[input.name]
+    if value == nil and input.getDefaultValue then
+      value = input.getDefaultValue(context)
+    end
+    values[input.name] = value
+  end
+
+  vim.schedule(function()
+    inputs.fill(context, buf, values, true)
+
+    vim.notify('grug-far: swapped to engine: ' .. context.engine.type .. '!', vim.log.levels.INFO)
+
+    local win = vim.fn.bufwinid(buf)
+    pcall(vim.api.nvim_win_set_cursor, win, { context.options.startCursorRow, 0 })
+    search({ buf = buf, context = context })
+  end)
 end
 
 return swapEngine

--- a/lua/grug-far/actions/swapEngine.lua
+++ b/lua/grug-far/actions/swapEngine.lua
@@ -14,6 +14,10 @@ local function swapEngine(params)
   context.engine = engine.getEngine(nextEngineType)
   vim.notify('grug-far: swapped to engine: ' .. context.engine.type .. '!', vim.log.levels.INFO)
   search({ buf = buf, context = context })
+
+  -- TODO (sbadragan): need to somehow clear the extmark that was rendered for Search: input...
+  -- and the associated value
+  -- then fillInput with default for the ones that have a default.
 end
 
 return swapEngine

--- a/lua/grug-far/actions/swapReplacementInterpreter.lua
+++ b/lua/grug-far/actions/swapReplacementInterpreter.lua
@@ -7,6 +7,13 @@ local function swapReplacementInterpreter(params)
   local context = params.context
   local buf = params.buf
 
+  local isReplacementInterpreterUsed = vim.iter(context.engine.inputs):find(function(input)
+    return input.replacementInterpreterEnabled
+  end)
+  if not isReplacementInterpreterUsed then
+    return
+  end
+
   local interpreters = vim.deepcopy(context.options.enabledReplacementInterpreters)
   table.insert(interpreters, 'default')
   local currentIndex = vim.fn.index(

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -83,6 +83,7 @@ M.DiffSeparatorChars = ' '
 ---@field highlightLang? string
 ---@field trim boolean
 ---@field replacementInterpreterEnabled? boolean
+---@field getDefaultValue? fun(context: GrugFarContext): string
 
 ---@class GrugFarEngine
 ---@field type GrugFarEngineType

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -93,6 +93,7 @@ M.DiffSeparatorChars = ' '
 ---@field isSyncSupported fun(): boolean whether sync operation is supported
 ---@field sync fun(params: EngineSyncParams): (abort: fun()?) syncs given changes to their originating files
 ---@field getInputPrefillsForVisualSelection fun(visual_selection: string[], initialPrefills: GrugFarPrefills): GrugFarPrefills gets prefills updated with visual selection searchand any additional flags that are necessary (for example --fixed-strings for rg)
+---@field getSearchDescription fun(inputs: GrugFarInputs): string a string describing the current search to be used as buffer title for example
 
 --- returns engine given type
 ---@param type GrugFarEngineType

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -82,6 +82,7 @@ M.DiffSeparatorChars = ' '
 ---@field iconName string
 ---@field highlightLang? string
 ---@field trim boolean
+---@field replacementInterpreterEnabled? boolean
 
 ---@class GrugFarEngine
 ---@field type GrugFarEngineType

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -76,8 +76,16 @@ M.DiffSeparatorChars = ' '
 ---@field report_progress fun(update: { type: "update_total" | "update_count", count: integer })
 ---@field on_finish fun(status: GrugFarStatus, errorMessage: string?, customActionMessage: string?)
 
+---@class GrugFarEngineInput
+---@field name string
+---@field label string
+---@field iconName string
+---@field highlightLang? string
+---@field trim boolean
+
 ---@class GrugFarEngine
 ---@field type GrugFarEngineType
+---@field inputs GrugFarEngineInput[]
 ---@field isSearchWithReplacement fun(inputs: GrugFarInputs, options: GrugFarOptions): boolean is this a search with replacement
 ---@field showsReplaceDiff fun(options: GrugFarOptions): boolean whether we show a diff when replacing
 ---@field search fun(params: EngineSearchParams): (abort: fun()?, effectiveArgs: string[]?) performs search

--- a/lua/grug-far/engine.lua
+++ b/lua/grug-far/engine.lua
@@ -94,6 +94,7 @@ M.DiffSeparatorChars = ' '
 ---@field sync fun(params: EngineSyncParams): (abort: fun()?) syncs given changes to their originating files
 ---@field getInputPrefillsForVisualSelection fun(visual_selection: string[], initialPrefills: GrugFarPrefills): GrugFarPrefills gets prefills updated with visual selection searchand any additional flags that are necessary (for example --fixed-strings for rg)
 ---@field getSearchDescription fun(inputs: GrugFarInputs): string a string describing the current search to be used as buffer title for example
+---@field isEmptySearch fun(inputs: GrugFarInputs, options: GrugFarOptions): boolean whether search query is empty
 
 --- returns engine given type
 ---@param type GrugFarEngineType

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -69,6 +69,10 @@ local AstgrepEngine = {
     prefills.search = table.concat(visual_selection, '\n')
     return prefills
   end,
+
+  getSearchDescription = function(inputs)
+    return inputs.search
+  end,
 }
 
 return AstgrepEngine

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -7,19 +7,11 @@ local AstgrepEngine = {
 
   inputs = {
     {
-      -- TODO (sbadragan): test with a rules one
-      -- TODO (sbadragan): set back
-      name = 'rules',
-      label = 'Rules',
+      name = 'search',
+      label = 'Search',
       iconName = 'searchInput',
       highlightLang = 'regex',
       trim = false,
-      getDefaultValue = function(context)
-        return [[
-hello world
-of many rules]]
-      end,
-      -- TODO (sbadragan): clear the flags with default value??
     },
     {
       name = 'replacement',

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -7,8 +7,10 @@ local AstgrepEngine = {
 
   inputs = {
     {
-      name = 'search',
-      label = 'Search',
+      -- TODO (sbadragan): test with a rules one
+      -- TODO (sbadragan): set back
+      name = 'rules',
+      label = 'Rules',
       iconName = 'searchInput',
       highlightLang = 'regex',
       trim = false,
@@ -72,6 +74,10 @@ local AstgrepEngine = {
 
   getSearchDescription = function(inputs)
     return inputs.search
+  end,
+
+  isEmptySearch = function(inputs)
+    return #inputs.search == 0
   end,
 }
 

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -5,6 +5,44 @@ local replace = require('grug-far.engine.astgrep.replace')
 local AstgrepEngine = {
   type = 'astgrep',
 
+  inputs = {
+    {
+      name = 'search',
+      label = 'Search',
+      iconName = 'searchInput',
+      highlightLang = 'regex',
+      trim = false,
+    },
+    {
+      name = 'replacement',
+      label = 'Replace',
+      iconName = 'replaceInput',
+      highlightLang = nil,
+      trim = false,
+    },
+    {
+      name = 'filesFilter',
+      label = 'Files Filter',
+      iconName = 'filesFilterInput',
+      highlightLang = 'gitignore',
+      trim = true,
+    },
+    {
+      name = 'flags',
+      label = 'Flags',
+      iconName = 'flagsInput',
+      highlightLang = 'bash',
+      trim = true,
+    },
+    {
+      name = 'paths',
+      label = 'Paths',
+      iconName = 'pathsInput',
+      highlightLang = 'bash',
+      trim = true,
+    },
+  },
+
   isSearchWithReplacement = function(inputs, options)
     local args = search.getSearchArgs(inputs, options)
     return search.isSearchWithReplacement(args)

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -14,6 +14,12 @@ local AstgrepEngine = {
       iconName = 'searchInput',
       highlightLang = 'regex',
       trim = false,
+      getDefaultValue = function(context)
+        return [[
+hello world
+of many rules]]
+      end,
+      -- TODO (sbadragan): clear the flags with default value??
     },
     {
       name = 'replacement',

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -21,6 +21,7 @@ local AstgrepEngine = {
       iconName = 'replaceInput',
       highlightLang = nil,
       trim = false,
+      replacementInterpreterEnabled = true,
     },
     {
       name = 'filesFilter',

--- a/lua/grug-far/engine/astgrep/search.lua
+++ b/lua/grug-far/engine/astgrep/search.lua
@@ -135,6 +135,17 @@ function M.search(params)
     )
     return
   end
+  local numSearchChars = #params.inputs.search
+  if numSearchChars > 0 and numSearchChars < (params.options.minSearchChars or 1) then
+    params.on_finish(
+      'success',
+      nil,
+      'Please enter at least '
+        .. params.options.minSearchChars
+        .. ' search chars to trigger search!'
+    )
+    return
+  end
 
   local rg_version = getRgVersion(params.options)
   if not rg_version then

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -6,10 +6,6 @@ local sync = require('grug-far.engine.ripgrep.sync')
 local RipgrepEngine = {
   type = 'ripgrep',
 
-  -- TODO (sbadragan): what do do on engine change default behaviour
-  -- TODO (sbadragan): test with a rules one
-  --   we can omit rendering the Replace input for astgrep-rules
-  --  we could define labels for each input in opts, similar to how we now do placeholders. So we could rename Search to Rules for astgrep-rules engine specifically.
   inputs = {
     {
       name = 'search',
@@ -85,6 +81,10 @@ local RipgrepEngine = {
 
   getSearchDescription = function(inputs)
     return inputs.search
+  end,
+
+  isEmptySearch = function(inputs)
+    return #inputs.search == 0
   end,
 }
 

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -20,6 +20,7 @@ local RipgrepEngine = {
       iconName = 'replaceInput',
       highlightLang = nil,
       trim = false,
+      replacementInterpreterEnabled = true,
     },
     {
       name = 'filesFilter',

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -82,6 +82,10 @@ local RipgrepEngine = {
 
     return prefills
   end,
+
+  getSearchDescription = function(inputs)
+    return inputs.search
+  end,
 }
 
 return RipgrepEngine

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -6,6 +6,53 @@ local sync = require('grug-far.engine.ripgrep.sync')
 local RipgrepEngine = {
   type = 'ripgrep',
 
+  -- TODO (sbadragan): update history
+  --   we can omit rendering the Replace input for astgrep-rules
+  -- we could define labels for each input in opts, similar to how we now do placeholders. So we could rename Search to Rules for astgrep-rules engine specifically.
+  -- we can have prefills respect those inputs
+  -- we can have history respect those input labels
+  -- TODO (sbadragan): update prefills
+  -- TODO (sbadragan): what do do on engine change default behaviour
+  -- TODO (sbadragan): Ideally we would make higlightLang configurable per input per engine
+  -- TODO (sbadragan): test with a rules one
+  inputs = {
+    {
+      name = 'search',
+      label = 'Search',
+      iconName = 'searchInput',
+      highlightLang = 'regex',
+      trim = false,
+    },
+    {
+      name = 'replacement',
+      label = 'Replace',
+      iconName = 'replaceInput',
+      highlightLang = nil,
+      trim = false,
+    },
+    {
+      name = 'filesFilter',
+      label = 'Files Filter',
+      iconName = 'filesFilterInput',
+      highlightLang = 'gitignore',
+      trim = true,
+    },
+    {
+      name = 'flags',
+      label = 'Flags',
+      iconName = 'flagsInput',
+      highlightLang = 'bash',
+      trim = true,
+    },
+    {
+      name = 'paths',
+      label = 'Paths',
+      iconName = 'pathsInput',
+      highlightLang = 'bash',
+      trim = true,
+    },
+  },
+
   isSearchWithReplacement = function(inputs, options)
     local args = search.getSearchArgs(inputs, options)
     return search.isSearchWithReplacement(args)

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -6,15 +6,10 @@ local sync = require('grug-far.engine.ripgrep.sync')
 local RipgrepEngine = {
   type = 'ripgrep',
 
-  -- TODO (sbadragan): update history
-  --   we can omit rendering the Replace input for astgrep-rules
-  -- we could define labels for each input in opts, similar to how we now do placeholders. So we could rename Search to Rules for astgrep-rules engine specifically.
-  -- we can have prefills respect those inputs
-  -- we can have history respect those input labels
-  -- TODO (sbadragan): update prefills
   -- TODO (sbadragan): what do do on engine change default behaviour
-  -- TODO (sbadragan): Ideally we would make higlightLang configurable per input per engine
   -- TODO (sbadragan): test with a rules one
+  --   we can omit rendering the Replace input for astgrep-rules
+  --  we could define labels for each input in opts, similar to how we now do placeholders. So we could rename Search to Rules for astgrep-rules engine specifically.
   inputs = {
     {
       name = 'search',

--- a/lua/grug-far/engine/ripgrep/search.lua
+++ b/lua/grug-far/engine/ripgrep/search.lua
@@ -328,6 +328,18 @@ function M.search(params)
     )
     return
   end
+  -- TODO (sbadragan): need to fixup types on inputs
+  local numSearchChars = #params.inputs.search
+  if numSearchChars > 0 and numSearchChars < (params.options.minSearchChars or 1) then
+    params.on_finish(
+      'success',
+      nil,
+      'Please enter at least '
+        .. params.options.minSearchChars
+        .. ' search chars to trigger search!'
+    )
+    return
+  end
 
   local args = M.getSearchArgs(params.inputs, params.options)
   local isSearchWithReplace = M.isSearchWithReplacement(args)

--- a/lua/grug-far/engine/ripgrep/search.lua
+++ b/lua/grug-far/engine/ripgrep/search.lua
@@ -328,7 +328,6 @@ function M.search(params)
     )
     return
   end
-  -- TODO (sbadragan): need to fixup types on inputs
   local numSearchChars = #params.inputs.search
   if numSearchChars > 0 and numSearchChars < (params.options.minSearchChars or 1) then
     params.on_finish(

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -357,7 +357,15 @@ function M.createBuffer(win, context)
     render(buf, context)
 
     vim.schedule(function()
-      inputs.fill(context, buf, context.options.prefills, true)
+      local values = {}
+      for _, input in ipairs(context.engine.inputs) do
+        local value = context.options.prefills[input.name]
+        if value == nil and input.getDefaultValue then
+          value = input.getDefaultValue(context)
+        end
+        values[input.name] = value
+      end
+      inputs.fill(context, buf, values, true)
       updateBufName(buf, context)
 
       pcall(vim.api.nvim_win_set_cursor, win, { context.options.startCursorRow, 0 })

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -298,8 +298,8 @@ function M.createBuffer(win, context)
 
     -- do a search immediately if either:
     -- 1. manually searching
-    -- 2. auto debounce searching and query is empty string, to improve responsiveness
-    if state.normalModeSearch or state.inputs.search == '' then
+    -- 2. auto debounce searching and query is empty, to improve responsiveness
+    if state.normalModeSearch or context.engine.isEmptySearch(state.inputs, context.options) then
       search({ buf = buf, context = context })
     else
       debouncedSearch({ buf = buf, context = context })

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -223,7 +223,7 @@ local function updateBufName(buf, context)
   else
     title = getNextUniqueBufName(buf, 'Grug FAR', true)
       .. utils.strEllideAfter(
-        context.state.inputs.search,
+        context.engine.getSearchDescription(context.state.inputs),
         context.options.maxSearchCharsInTitles,
         ': '
       )

--- a/lua/grug-far/inputs.lua
+++ b/lua/grug-far/inputs.lua
@@ -32,7 +32,7 @@ end
 --- if clearOld is true, clear old values even if new value not given
 ---@param context GrugFarContext
 ---@param buf integer
----@param values GrugFarPrefills | GrugFarPrefillsOverride
+---@param values GrugFarPrefills
 ---@param clearOld boolean
 function M.fill(context, buf, values, clearOld)
   -- filling in reverse order as it's more reliable with the left gravity extmarks

--- a/lua/grug-far/inputs.lua
+++ b/lua/grug-far/inputs.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+-- TODO (sbadragan): remove this?
 ---@enum InputNames
 M.InputNames = {
   search = 'search',

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -260,11 +260,11 @@ M.defaultOptions = {
   -- require('grug-far').open({ prefills = { search = vim.fn.expand("<cword>") } })
   --
   prefills = {
-    search = '',
-    replacement = '',
-    filesFilter = '',
-    flags = '',
-    paths = '',
+    search = nil,
+    replacement = nil,
+    filesFilter = nil,
+    flags = nil,
+    paths = nil,
   },
 
   -- search history settings
@@ -489,13 +489,6 @@ M.defaultOptions = {
 ---@field paths? string
 
 ---@class GrugFarPrefills
----@field search string
----@field replacement string
----@field filesFilter string
----@field flags string
----@field paths string
-
----@class GrugFarPrefillsOverride
 ---@field search? string
 ---@field replacement? string
 ---@field filesFilter? string
@@ -641,7 +634,7 @@ M.defaultOptions = {
 ---@field spinnerStates? string[] | false
 ---@field reportDuration? boolean
 ---@field icons? IconsTableOverride
----@field prefills? GrugFarPrefillsOverride
+---@field prefills? GrugFarPrefills
 ---@field history? HistoryTableOverride
 ---@field instanceName? string
 ---@field folding? FoldingTableOverride

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -66,6 +66,7 @@ M.defaultOptions = {
         search = 'e.g. foo   foo([a-z0-9]*)   fun\\(',
         replacement = 'e.g. bar   ${1}_foo   $$MY_ENV_VAR ',
         replacement_lua = 'e.g. if vim.startsWith(match, "use") \\n then return "employ" .. match \\n else return match end',
+        replacement_vimscript = 'e.g. return "bob_" .. match',
         filesFilter = 'e.g. *.lua   *.{css,js}   **/docs/*.md   (specify one per line)',
         flags = 'e.g. --help --ignore-case (-i) --replace= (empty replace) --multiline (-U)',
         paths = 'e.g. /foo/bar   ../   ./hello\\ world/   ./src/foo.lua   ~/.config',

--- a/lua/grug-far/render.lua
+++ b/lua/grug-far/render.lua
@@ -32,8 +32,7 @@ local function render(buf, context)
     local placeholder = placeholders[input.name]
     local highlightLang = input.highlightLang
 
-    -- special treatment for replacement interpreter
-    if input.name == 'replacement' then
+    if input.replacementInterpreterEnabled then
       local interpreterType = context.replacementInterpreter and context.replacementInterpreter.type
         or nil
       if interpreterType then

--- a/lua/grug-far/render.lua
+++ b/lua/grug-far/render.lua
@@ -22,10 +22,10 @@ local function render(buf, context)
     }, context)
   end
 
-  lineNr = lineNr + TOP_EMPTY_LINES - 1
+  lineNr = lineNr + TOP_EMPTY_LINES
 
   for i, input in ipairs(context.engine.inputs) do
-    lineNr = lineNr + 1
+    local prevInput = context.engine.inputs[i - 1]
     local nextInput = context.engine.inputs[i + 1]
 
     local label = input.label
@@ -47,6 +47,7 @@ local function render(buf, context)
       buf = buf,
       lineNr = lineNr,
       extmarkName = input.name,
+      prevExtmarkName = prevInput and prevInput.name or nil,
       nextExtmarkName = nextInput and nextInput.name or 'results_header',
       icon = input.iconName,
       label = label .. ':',
@@ -55,9 +56,10 @@ local function render(buf, context)
     }, context)
 
     state.inputs[input.name] = input.trim and vim.trim(value) or value
+
+    lineNr = lineNr + 1
   end
 
-  lineNr = lineNr + 1
   renderResults({
     buf = buf,
     minLineNr = lineNr,

--- a/lua/grug-far/render/resultsList.lua
+++ b/lua/grug-far/render/resultsList.lua
@@ -149,7 +149,6 @@ function M.appendResultsChunk(buf, context, data)
     end
   end
 
-  -- TODO (sbadragan): add a test for long line search
   if maxLineLength > -1 then
     local trimmedLineMsgLen = #getTrimmedLineMessage(maxLineLength)
     for i = 1, #data.lines do


### PR DESCRIPTION
helps with https://github.com/MagicDuck/grug-far.nvim/issues/363

With this change, we can:
1. we can omit rendering the Replace input for astgrep-rules
2. we could define labels for each input. So we could rename Search to Rules for astgrep-rules engine specifically.
3. we can have prefills respect those inputs
4. we can have history respect those input labels
5. we can define highlight lang for each input