### PR TITLE
feat: upload rockspec on a tag to luarocks.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: LuaRocks release
+on:
+  push:
+    tags: # Will upload to luarocks.org when a tag is pushed
+      - "*"
+  pull_request: # Will test a local install without uploading to luarocks.org
+
+jobs:
+  luarocks-release:
+    runs-on: ubuntu-latest
+    name: LuaRocks upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v7
+        with:
+          name: grug-far.nvim
+          labels: neovim
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}


### PR DESCRIPTION
to help with installations like rocks.nvim or lazy.nvim or plugins/neovim distributions that want to depend on it.

To be able to upload to luarocks, the owner of the luarocks account will have to add an API key named `LUAROCKS_API_KEY` to this repo's GitHub Actions secrets.

![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211114453-193dd454-a842-4e8f-a083-fe73c530a51d.png)

cc @mrcjkb