### PR TITLE
fix(ast-grep): rename binary from sg to ast-grep

### DIFF
--- a/lua/grug-far/health.lua
+++ b/lua/grug-far/health.lua
@@ -16,7 +16,7 @@ local dependencies = {
     optional = false,
   },
   {
-    name = 'sg',
+    name = 'ast-grep',
     url = '[ast-grep](https://ast-grep.github.io)',
     optional = true,
   },

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -109,7 +109,7 @@ M.defaultOptions = {
 
     ['astgrep-rules'] = {
       -- ast-grep executable to use, can be a different path if you need to configure
-      path = 'sg',
+      path = 'ast-grep',
 
       -- extra args that you always want to pass
       -- like for example if you always want context lines around matches

--- a/lua/grug-far/test/helpers.lua
+++ b/lua/grug-far/test/helpers.lua
@@ -110,7 +110,7 @@ function M.getSetupOptions()
         placeholders = { enabled = false },
       },
       astgrep = {
-        path = vim.env.SG_PATH or 'sg',
+        path = vim.env.SG_PATH or 'ast-grep',
         rgPath = vim.env.RG_PATH or 'rg',
         placeholders = { enabled = false },
       },

--- a/tests/astgrep-rules/test_search.lua
+++ b/tests/astgrep-rules/test_search.lua
@@ -75,7 +75,7 @@ rule:
   helpers.childExpectBufLines(child)
 end
 
-T['reports error from sg'] = function()
+T['reports error from ast-grep'] = function()
   helpers.writeTestFiles({
     {
       filename = 'file2.ts',

--- a/tests/astgrep/test_search.lua
+++ b/tests/astgrep/test_search.lua
@@ -65,7 +65,7 @@ T['can search for some string with placeholders on'] = function()
   helpers.childExpectBufLines(child)
 end
 
-T['reports error from sg'] = function()
+T['reports error from ast-grep'] = function()
   helpers.writeTestFiles({
     {
       filename = 'file2.ts',


### PR DESCRIPTION
Continuation of https://github.com/MagicDuck/grug-far.nvim/pull/394.

I ran into an issue with `:checkhealth` breaking because grug-far was executing `sg`, which happened to be a different program and messed up my neovim instance each time I ran it. I saw you started the work and I thought I could just finish it.