### PR TITLE
Add backspaceEol option to allow deleting eols in search box

### DIFF
--- a/doc/grug-far-opts.txt
+++ b/doc/grug-far-opts.txt
@@ -250,6 +250,9 @@
     -- whether or not to make a transient buffer which is both unlisted and fully deletes itself when not in use
     transient = false,
 
+    -- whether or not to allow the backspace key to delete an EOL character
+    backspaceEol = false,
+
     -- by default, in visual mode, the visual selection is used to prefill the search
     -- setting this option to true disables that behaviour
     -- deprecated, please use visualSelectionUsage instead
@@ -699,6 +702,7 @@ Fields ~
 Class ~
 {grug.far.Options}
 Fields ~
+{backspaceEol} `(boolean)`
 {debounceMs} `(integer)`
 {minSearchChars} `(integer)`
 {maxSearchMatches} `(integer?)`

--- a/doc/grug-far-opts.txt
+++ b/doc/grug-far-opts.txt
@@ -250,7 +250,8 @@
     -- whether or not to make a transient buffer which is both unlisted and fully deletes itself when not in use
     transient = false,
 
-    -- whether or not to allow the backspace key to delete an EOL character
+    -- whether or not to allow the <BS>, <Del> Ctrl-W, and, Ctrl-U key to delete an EOL character;
+    -- when disabled, deletions will be limited to the current line.
     backspaceEol = false,
 
     -- by default, in visual mode, the visual selection is used to prefill the search

--- a/lua/grug-far/farBuffer.lua
+++ b/lua/grug-far/farBuffer.lua
@@ -278,7 +278,7 @@ end
 
 ---@param buf integer
 ---@param context grug.far.Context
-local function setupGlobalOptOverrides(buf, context)
+local function setupGlobalBackspaceOptOverrides(buf, context)
   local originalBackspaceOpt
   local function apply_overrides()
     -- this prevents backspacing over eol when clearing an input line
@@ -318,7 +318,9 @@ function M.setupBuffer(win, buf, context, on_ready)
     vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = buf })
   end
 
-  setupGlobalOptOverrides(buf, context)
+  if not context.options.backspaceEol then
+    setupGlobalBackspaceOptOverrides(buf, context)
+  end
   context.actions = getActions(buf, context)
   for _, action in ipairs(context.actions) do
     utils.setBufKeymap(buf, action.text, action.keymap, action.action)

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -251,6 +251,9 @@ grug_far.defaultOptions = {
   -- whether or not to make a transient buffer which is both unlisted and fully deletes itself when not in use
   transient = false,
 
+  -- whether or not to allow the backspace key to delete an EOL character
+  backspaceEol = false,
+
   -- by default, in visual mode, the visual selection is used to prefill the search
   -- setting this option to true disables that behaviour
   -- deprecated, please use visualSelectionUsage instead
@@ -804,6 +807,7 @@ grug_far.defaultOptions = {
 
 ---@class grug.far.Options
 ---@tag grug.far.Options
+---@field backspaceEol boolean
 ---@field debounceMs integer
 ---@field minSearchChars integer
 ---@field maxSearchMatches integer?

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -251,7 +251,8 @@ grug_far.defaultOptions = {
   -- whether or not to make a transient buffer which is both unlisted and fully deletes itself when not in use
   transient = false,
 
-  -- whether or not to allow the backspace key to delete an EOL character
+  -- whether or not to allow the <BS>, <Del> Ctrl-W, and, Ctrl-U key to delete an EOL character;
+  -- when disabled, deletions will be limited to the current line.
   backspaceEol = false,
 
   -- by default, in visual mode, the visual selection is used to prefill the search

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -35,7 +35,6 @@
 ---@field action? fun()
 
 ---@class grug.far.Context
----@field backspaceEol boolean
 ---@field count integer
 ---@field options grug.far.Options
 ---@field namespace integer

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -35,6 +35,7 @@
 ---@field action? fun()
 
 ---@class grug.far.Context
+---@field backspaceEol boolean
 ---@field count integer
 ---@field options grug.far.Options
 ---@field namespace integer


### PR DESCRIPTION
Fixes #519 

It bothered me that pressing delete in the input box didn't delete empty lines, but it looks like this was deliberate behavior. I have gone ahead and made it an option :) The video shows `backspaceEol` as `true`.


https://github.com/user-attachments/assets/5d5714e9-e10c-4499-8cf5-ccbfb805d676

