### PR TITLE
Determine if buf is valid.

### DIFF
--- a/lua/grug-far/actions/search.lua
+++ b/lua/grug-far/actions/search.lua
@@ -18,6 +18,10 @@ local function search(params)
   local context = params.context
   local state = context.state
 
+  if not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
   if tasks.hasActiveTasksWithType(context, 'sync') then
     vim.notify('grug-far: sync in progress', vim.log.levels.INFO)
     return


### PR DESCRIPTION
If I open 'grug-far' and close it before search results appear, an error occurs.
So, we should validate the buf.
Since I set shortcuts for quick open and close, I can complete the operation quickly.

```
require('grug-far').open({ 
    prefills = { 
        search = vim.fn.expand("<cword>"),
        paths = vim.fs.normalize(vim.fn.expand("%"))
    } 
})
```

![PixPin_2025-10-10_08-46-55](https://github.com/user-attachments/assets/f9314f2e-db1c-4fc2-a646-9a7d9092c27e)


```
vim.schedule callback: ...cal/nvim-data/lazy/grug-far.nvim/lua/grug-far/inputs.lua:30: Invalid buffer id: 17            
stack traceback:                                                                                                                
[C]: in function 'nvim_buf_get_extmark_by_id'                                                                           
...cal/nvim-data/lazy/grug-far.nvim/lua/grug-far/inputs.lua:30: in function 'getInputPos'                               
...cal/nvim-data/lazy/grug-far.nvim/lua/grug-far/inputs.lua:43: in function 'getInputLines'                             
...cal/nvim-data/lazy/grug-far.nvim/lua/grug-far/inputs.lua:58: in function 'getInputValue'                             
...cal/nvim-data/lazy/grug-far.nvim/lua/grug-far/inputs.lua:74: in function 'getValues'                                 
...-data/lazy/grug-far.nvim/lua/grug-far/actions/search.lua:156: in function 'fn'                                       
vim/_editor.lua:296: in function <vim/_editor.lua:295>    
```