### PR TITLE
add uiMode

### DIFF
--- a/lua/grug-far/engine/astgrep-rules.lua
+++ b/lua/grug-far/engine/astgrep-rules.lua
@@ -91,7 +91,7 @@ rule:
     },
     {
       name = 'filesFilter',
-      label = 'Files Filter',
+      label = 'Filter',
       iconName = 'filesFilterInput',
       highlightLang = 'gitignore',
       trim = true,

--- a/lua/grug-far/engine/astgrep.lua
+++ b/lua/grug-far/engine/astgrep.lua
@@ -24,7 +24,7 @@ local AstgrepEngine = {
     },
     {
       name = 'filesFilter',
-      label = 'Files Filter',
+      label = 'Filter',
       iconName = 'filesFilterInput',
       highlightLang = 'gitignore',
       trim = true,

--- a/lua/grug-far/engine/ripgrep.lua
+++ b/lua/grug-far/engine/ripgrep.lua
@@ -25,7 +25,7 @@ local RipgrepEngine = {
     },
     {
       name = 'filesFilter',
-      label = 'Files Filter',
+      label = 'Filter',
       iconName = 'filesFilterInput',
       highlightLang = 'gitignore',
       trim = true,

--- a/lua/grug-far/opts.lua
+++ b/lua/grug-far/opts.lua
@@ -246,6 +246,8 @@ grug_far.defaultOptions = {
   -- whether to show a more compact version of the inputs UI
   showCompactInputs = false,
 
+  uiMode = 'default',
+
   -- whether inputs top padding line should be present
   showInputsTopPadding = true,
 
@@ -868,6 +870,7 @@ grug_far.defaultOptions = {
 ---@field startInInsertMode boolean
 ---@field startCursorRow integer
 ---@field showCompactInputs boolean
+---@field uiMode string
 ---@field showInputsTopPadding boolean
 ---@field showInputsBottomPadding boolean
 ---@field showStatusIcon boolean
@@ -925,6 +928,7 @@ grug_far.defaultOptions = {
 ---@field startInInsertMode? boolean
 ---@field startCursorRow? integer
 ---@field showCompactInputs? boolean
+---@field uiMode? string
 ---@field showInputsTopPadding? boolean
 ---@field showInputsBottomPadding? boolean
 ---@field showStatusIcon? boolean

--- a/lua/grug-far/render.lua
+++ b/lua/grug-far/render.lua
@@ -45,7 +45,7 @@ local function render(buf, context)
       prevExtmarkName = prevInput and prevInput.name or nil,
       nextExtmarkName = nextInput and nextInput.name or 'results_header',
       icon = input.iconName,
-      label = label .. ':',
+      label = label,
       placeholder = placeholders.enabled and placeholder,
       highlightLang = inputsHighlight and highlightLang or nil,
       top_virt_lines = i == 1 and top_virt_lines or nil,


### PR DESCRIPTION
<img width="453" height="180" alt="image" src="https://github.com/user-attachments/assets/a20b48a4-098f-4603-a33e-0910817bdc30" />

<img width="449" height="206" alt="image" src="https://github.com/user-attachments/assets/77285dc7-e1ac-4194-afde-a8091806ed05" />

<img width="453" height="150" alt="image" src="https://github.com/user-attachments/assets/0bcccf73-ab58-44de-a1a8-ae3a6388db4e" />


```lua
uiMode = 'editbox'
```
This is the method I'm using; the code is for reference only.
The code has some breaking changes: the 'Files Filter' label was too long, so I shortened it.
