### PR TITLE
feat: complete command with context

### DIFF
--- a/plugin/grug-far.lua
+++ b/plugin/grug-far.lua
@@ -6,11 +6,15 @@ if vim.fn.has('nvim-0.11.0') == 0 then
   return
 end
 
--- note: unfortunately has to be global so it can be passed to command complete= opt
--- selene: allow(unused_variable)
-function GrugFarCompleteEngine()
-  local opts = require('grug-far.opts')
-  return table.concat(vim.fn.keys(opts.defaultOptions.engines), '\n')
+---Create command complete fn.
+---@param name string
+---@return grug.far.CmdCompleteFn
+local function cmd_complete(name)
+  return require('grug-far.utils').create_cmd_complete(function(ctx)
+    if ctx.prev == name then
+      return vim.tbl_keys(require('grug-far.opts').defaultOptions.engines)
+    end
+  end)
 end
 
 vim.api.nvim_create_user_command('GrugFar', function(params)
@@ -33,7 +37,7 @@ vim.api.nvim_create_user_command('GrugFar', function(params)
 end, {
   nargs = '?',
   range = true,
-  complete = 'custom,v:lua.GrugFarCompleteEngine',
+  complete = cmd_complete('GrugFar'),
 })
 
 vim.api.nvim_create_user_command('GrugFarWithin', function(params)
@@ -57,5 +61,5 @@ vim.api.nvim_create_user_command('GrugFarWithin', function(params)
 end, {
   nargs = '?',
   range = true,
-  complete = 'custom,v:lua.GrugFarCompleteEngine',
+  complete = cmd_complete('GrugFarWithin'),
 })

--- a/tests/base/test_utils.lua
+++ b/tests/base/test_utils.lua
@@ -46,3 +46,36 @@ describe('detect_eol', function()
     expect.equality(utils.detect_eol('\nline2'), '\n')
   end)
 end)
+
+describe('create_cmd_complete', function()
+  it('get correct prev', function()
+    local tests = {
+      {
+        input = { '', 'Grug' },
+        prev = 'Grug',
+      },
+      {
+        input = { '', 'Grug   ' },
+        prev = 'Grug',
+      },
+      {
+        input = { 'a', 'Grug   a' },
+        prev = 'Grug',
+      },
+      {
+        input = { 'Far', 'Grug  Far' },
+        prev = 'Grug',
+      },
+      {
+        input = { '', 'Grug  Far  ' },
+        prev = 'Far',
+      },
+    }
+
+    for _, test in ipairs(tests) do
+      utils.create_cmd_complete(function(ctx)
+        expect.equality(test.prev, ctx.prev)
+      end)(test.input[1], test.input[2], #test.input[2])
+    end
+  end)
+end)


### PR DESCRIPTION
Add context in command-line completion.

After the first completion is done, pressing `Tab` again continues to show more completions. This is not what we want.
```vim
:GrugFar ripgrep <Tab>
```

Currently, the command-line information is very simple, only completing the engine.

Should we consider enriching the command-line commands? For example, adding several commonly used parameters from the query interface, like paths, filter, etc., to the command line.