### PR TITLE
test: update test dependencies & screenshot tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ['v0.11.0']
+        neovim_version: ['v0.12.1']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -31,12 +31,12 @@ jobs:
         run: |
           mkdir -p deps/ripgrep
           cd deps/ripgrep
-          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep-14.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
+          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
       - name: Install astgrep
         run: |
           mkdir -p deps/astgrep
           cd deps/astgrep
-          wget https://github.com/ast-grep/ast-grep/releases/download/0.35.0/app-x86_64-unknown-linux-gnu.zip
+          wget https://github.com/ast-grep/ast-grep/releases/download/0.41.1/app-x86_64-unknown-linux-gnu.zip
           unzip app-x86_64-unknown-linux-gnu.zip
       - name: Run tests
         run: | 
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ['v0.11.0']
+        neovim_version: ['v0.12.1']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -63,12 +63,12 @@ jobs:
         run: |
           mkdir -p deps/ripgrep
           cd deps/ripgrep
-          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep-14.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
+          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
       - name: Install astgrep
         run: |
           mkdir -p deps/astgrep
           cd deps/astgrep
-          wget https://github.com/ast-grep/ast-grep/releases/download/0.35.0/app-x86_64-unknown-linux-gnu.zip
+          wget https://github.com/ast-grep/ast-grep/releases/download/0.41.1/app-x86_64-unknown-linux-gnu.zip
           unzip app-x86_64-unknown-linux-gnu.zip
       - name: Run tests
         run: | 
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ['v0.11.0']
+        neovim_version: ['v0.12.1']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -95,12 +95,12 @@ jobs:
         run: |
           mkdir -p deps/ripgrep
           cd deps/ripgrep
-          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep-14.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
+          wget -O - https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - --strip-component=1
       - name: Install astgrep
         run: |
           mkdir -p deps/astgrep
           cd deps/astgrep
-          wget https://github.com/ast-grep/ast-grep/releases/download/0.35.0/app-x86_64-unknown-linux-gnu.zip
+          wget https://github.com/ast-grep/ast-grep/releases/download/0.41.1/app-x86_64-unknown-linux-gnu.zip
           unzip app-x86_64-unknown-linux-gnu.zip
       - name: Run tests
         run: | 

--- a/lua/grug-far/test/dependencies.lua
+++ b/lua/grug-far/test/dependencies.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local NVIM_VERSION = '0.11.0'
-local RG_VERSION = '14.1.0'
-local SG_VERSION = '0.35.0'
+local NVIM_VERSION = '0.12.1'
+local RG_VERSION = '15.1.0'
+local SG_VERSION = '0.41.1'
 
 --- checks if it has required version of executable
 ---@param path string

--- a/tests/screenshots/tests-astgrep-rules-test_history.lua---engine-swaps-when-reloading-from-history-001
+++ b/tests/screenshots/tests-astgrep-rules-test_history.lua---engine-swaps-when-reloading-from-history-001
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: id: grug_test^@language: typesc...                             1,1
-24|grug-far: added current search to history!                    11,1          Top 
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-rules-test_history.lua---engine-swaps-when-reloading-from-history-002
+++ b/tests/screenshots/tests-astgrep-rules-test_history.lua---engine-swaps-when-reloading-from-history-002
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: grug                                                           1,1
-24|grug-far: added current search to history!                    3,1               
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-rules-test_replace.lua---can-replace-with-file-filter-001
+++ b/tests/screenshots/tests-astgrep-rules-test_replace.lua---can-replace-with-file-filter-001
@@ -13,3 +13,5 @@
 12| 
 13|      grug.walks(talks)
 14|      curly.walks(talks)
+15|Applied 2 changes
+16|

--- a/tests/screenshots/tests-astgrep-rules-test_search.lua---reports-error-from-ast-grep
+++ b/tests/screenshots/tests-astgrep-rules-test_search.lua---reports-error-from-ast-grep
@@ -20,6 +20,6 @@
 19|                                                                                
 20|  tip: a similar argument exists: '--stdin'                                     
 21|                                                                                
-22|Usage: ast-grep scan <PATHS|--follow|--no-ignore <FILE_TYPE>|--stdin|--globs @@@
+22|Usage: ast-grep scan --stdin [PATHS]...                                         
 23|Grug FAR - 1: id: grug_test^@language: typesc...                            1,14
 24|-- INSERT --                                                                    

--- a/tests/screenshots/tests-astgrep-test_history.lua---engine-swaps-when-reloading-from-history-001
+++ b/tests/screenshots/tests-astgrep-test_history.lua---engine-swaps-when-reloading-from-history-001
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: grug.$A                                                        1,1
-24|grug-far: added current search to history!                    11,1          Top 
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-test_history.lua---engine-swaps-when-reloading-from-history-002
+++ b/tests/screenshots/tests-astgrep-test_history.lua---engine-swaps-when-reloading-from-history-002
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: grug                                                           1,1
-24|grug-far: added current search to history!                    3,1               
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-001
+++ b/tests/screenshots/tests-astgrep-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-001
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: grug.$A                                                        1,1
-24|grug-far: added current search to history!                    11,1          Top 
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-002
+++ b/tests/screenshots/tests-astgrep-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-002
@@ -22,4 +22,4 @@
 21|▒   5                                                                           
 22|▒   6                                                                           
 23|Grug FAR - 1: $A                                                             1,1
-24|grug-far: added current search to history!                    3,1               
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-empty-string-001
+++ b/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-empty-string-001
@@ -10,3 +10,5 @@
 09| 
 10|      grug.walks(talks)
 11|      .walks(talks)
+12|Applied 2 changes
+13|

--- a/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-file-filter-001
+++ b/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-file-filter-001
@@ -10,3 +10,5 @@
 09| 
 10|      grug.walks(talks)
 11|      curly.walks(talks)
+12|Applied 2 changes
+13|

--- a/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-replace-string-001
+++ b/tests/screenshots/tests-astgrep-test_replace.lua---can-replace-with-replace-string-001
@@ -10,3 +10,5 @@
 09| 
 10|      grug.walks(talks)
 11|      curly.walks(talks)
+12|Applied 2 changes
+13|

--- a/tests/screenshots/tests-astgrep-test_search.lua---reports-error-from-ast-grep
+++ b/tests/screenshots/tests-astgrep-test_search.lua---reports-error-from-ast-grep
@@ -15,7 +15,7 @@
 14| STATUS_ERROR ⟪ astgrep ⟫
 15|                                                                                
 16|error: a value is required for '--strictness <STRICTNESS>' but none was supplied
-17|  [possible values: cst, smart, ast, relaxed, signature]                        
+17|  [possible values: cst, smart, ast, relaxed, signature, template]              
 18|                                                                                
 19|For more information, try '--help'.                                             
 20|                                                                                

--- a/tests/screenshots/tests-base-test_history.lua---can-manually-save-and-reload-from-history-002
+++ b/tests/screenshots/tests-base-test_history.lua---can-manually-save-and-reload-from-history-002
@@ -22,4 +22,4 @@
 21|  2       grug talks and grug drinks                                         [2]
 22|  3       then grug thinks and talks                                         [3]
 23|Grug FAR - 1: grug                                                           1,1
-24|grug-far: added current search to history!                    24,1          90% 
+24|grug-far: added current search to history!                                      

--- a/tests/screenshots/tests-base-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-001
+++ b/tests/screenshots/tests-base-test_history.lua---replacement-interpreter-swaps-when-reloading-from-history-001
@@ -22,4 +22,4 @@
 21|                                                                                
 22|                                                                                
 23|Grug FAR - 1: walks                                                          1,1
-24|grug-far: added current search to history!                    3,1               
+24|grug-far: added current search to history!                                      


### PR DESCRIPTION
Hey :wave: 

I'm a maintainer of the NixOS/nixpkgs Neovim ecosystem.
As part of our efforts to keep plugins working, we run the plugins' test suites whenever we update Neovim or plugins.

We're bumping Neovim to the 12.1 release (https://github.com/NixOS/nixpkgs/pull/507289) and the grug-far.nvim test suite started failing (screenshot tests, likely caused by changes to the Neovim UI).

This PR updates the test dependencies (Neovim, ripgrep, ast-grep) in CI and adjusts the screenshot tests.