### PR TITLE
fix: keep last line of visual selection ending on a lone char

### DIFF
--- a/lua/grug-far/utils.lua
+++ b/lua/grug-far/utils.lua
@@ -297,10 +297,14 @@ end
 function M.getVisualSelectionLines()
   local isVisualMode = M.isVisualMode()
 
+  local exclusive = vim.o.selection == 'exclusive'
+  -- getregionpos' end col is one less when exclusive, so only bump it back then
+  local end_bump = exclusive and 1 or 0
+
   local region = vim.fn.getregionpos(
     vim.fn.getpos(isVisualMode and '.' or "'<"),
     vim.fn.getpos(isVisualMode and 'v' or "'>"),
-    { type = isVisualMode and vim.fn.mode() or nil, exclusive = true }
+    { type = isVisualMode and vim.fn.mode() or nil, exclusive = exclusive }
   )
 
   local lines = {}
@@ -316,7 +320,7 @@ function M.getVisualSelectionLines()
   if end_col == vim.v.maxcol or (last_line and end_col >= #last_line) then
     end_col = -1
   else
-    end_col = end_col + 1
+    end_col = end_col + end_bump
   end
 
   for _, range in ipairs(region) do
@@ -332,7 +336,7 @@ function M.getVisualSelectionLines()
     if endcol == vim.v.maxcol then
       endcol = -1
     else
-      endcol = endcol + 1
+      endcol = endcol + end_bump
     end
     local line_text = vim.api.nvim_buf_get_text(0, line - 1, startcol, line - 1, endcol, {})[1]
     table.insert(lines, line_text)

--- a/tests/base/test_search.lua
+++ b/tests/base/test_search.lua
@@ -446,6 +446,41 @@ T['searches first line of multiline visual selection'] = function()
   helpers.childExpectScreenshot(child)
 end
 
+-- regression: a selection ending on a lone `}` at col 1 must keep that line
+T['keeps last line of visual selection ending on a lone bracket'] = function()
+  helpers.writeTestFiles({
+    { filename = 'file1', content = [[ grug walks ]] },
+    { filename = 'file2', content = 'func grug() {\n  return café\n}' },
+  })
+
+  helpers.cdTempTestDir(child)
+  child.cmd(':e file2')
+  -- gg0vG0 lands on the lone `}` at col 1; `$` would land one past it and miss the bug
+  child.type_keys(10, 'gg0vG0', '<esc>:<C-u>lua GrugFar.with_visual_selection()<CR>')
+
+  helpers.childWaitForFinishedStatus(child)
+
+  helpers.childExpectBufLines(child)
+  helpers.childExpectScreenshot(child)
+end
+
+-- counterpart: with selection=exclusive the `}` endpoint is correctly excluded
+T['excludes lone bracket endpoint when selection is exclusive'] = function()
+  helpers.writeTestFiles({
+    { filename = 'file1', content = [[ grug walks ]] },
+    { filename = 'file2', content = 'func grug() {\n  return café\n}' },
+  })
+
+  helpers.cdTempTestDir(child)
+  child.cmd(':e file2')
+  child.o.selection = 'exclusive'
+  child.type_keys(10, 'gg0vG0', '<esc>:<C-u>lua GrugFar.with_visual_selection()<CR>')
+
+  helpers.childWaitForFinishedStatus(child)
+
+  helpers.childExpectBufLines(child)
+end
+
 T['can trim long lines during search'] = function()
   helpers.writeTestFiles({
     {

--- a/tests/screenshots/tests-base-test_search.lua---excludes-lone-bracket-endpoint-when-selection-is-exclusive
+++ b/tests/screenshots/tests-base-test_search.lua---excludes-lone-bracket-endpoint-when-selection-is-exclusive
@@ -1,0 +1,10 @@
+-|---------|---
+1|func grug() {
+2|  return café
+3|
+4|
+5|--fixed-strings --multiline
+6|
+7|file2
+8|func grug() {
+9|  return café

--- a/tests/screenshots/tests-base-test_search.lua---keeps-last-line-of-visual-selection-ending-on-a-lone-bracket
+++ b/tests/screenshots/tests-base-test_search.lua---keeps-last-line-of-visual-selection-ending-on-a-lone-bracket
@@ -1,0 +1,12 @@
+--|---------|---
+01|func grug() {
+02|  return café
+03|}
+04|
+05|
+06|--fixed-strings --multiline
+07|
+08|file2
+09|func grug() {
+10|  return café
+11|}

--- a/tests/screenshots/tests-base-test_search.lua---keeps-last-line-of-visual-selection-ending-on-a-lone-bracket-001
+++ b/tests/screenshots/tests-base-test_search.lua---keeps-last-line-of-visual-selection-ending-on-a-lone-bracket-001
@@ -1,0 +1,25 @@
+--|---------|---------|---------|---------|---------|---------|---------|---------|
+01| Help g?    Replace ,r    Sync All ,s    Sync Line ,l ...                   
+02|                                                                                
+03|  Search:                                                                      
+04|func grug() {                                                                   
+05|  return café                                                                   
+06|}                                                                               
+07|  Replace:                                                                     
+08|                                                                                
+09|  Files Filter:                                                                
+10|                                                                                
+11| 󰮚 Flags:                                                                       
+12|--fixed-strings --multiline                                                     
+13|  Paths:                                                                       
+14|                                                                                
+15|                                                                                
+16| STATUS_SUCCESS ⟪ ripgrep ⟫─────────────────────────────────────────────────────
+17| 1 matches in 1 files                                                           
+18|                                                                                
+19|file2                                                                           
+20|  1 func grug() {                                                            [1]
+21|  2   return café                                                               
+22|  3 }                                                                           
+23|Grug FAR - 1: func grug() {^@  return café^@}                               1,14
+24|-- INSERT --                                                                    


### PR DESCRIPTION
for https://github.com/MagicDuck/grug-far.nvim/issues/594